### PR TITLE
LUM-18519 - change type to test-support-service so it does not includ…

### DIFF
--- a/src/deploy/cloudfoundry/app-descriptor.yml
+++ b/src/deploy/cloudfoundry/app-descriptor.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- type: basic-service
+- type: test-support-service
   memory: 1024M
   disk_quota: 20GB
   services:

--- a/src/deploy/cloudfoundry/app-descriptor.yml
+++ b/src/deploy/cloudfoundry/app-descriptor.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- type: test-support-service
+- type: internal-support-service
   memory: 1024M
   disk_quota: 20GB
   services:


### PR DESCRIPTION
…e an appD app agent

@Blackbaud-MikeLueders - I think changing this to "type" in the manifest will force this not to get an appD agent and therefore save us 2 licenses. Correct?
@Blackbaud-ChrisJenkins 