### PR TITLE
LUM-18519 - reduce to 1 instance

### DIFF
--- a/src/deploy/cloudfoundry/app-descriptor.yml
+++ b/src/deploy/cloudfoundry/app-descriptor.yml
@@ -1,6 +1,8 @@
 ---
 applications:
 - type: internal-support-service
+  instances: 1
+  blue_green_deploy: false
   memory: 1024M
   disk_quota: 20GB
   services:


### PR DESCRIPTION
I noticed we had 2 instances in prod. Is there a reason for that? If we don't need it, we should just specify 1 (cost) since this is not a customer facing tool. Thoughts?

@Blackbaud-ChrisJenkins 
@Blackbaud-MikeLueders 
@blackbaud/data-pipeline 